### PR TITLE
CSS footer adjustment so its not in the middle of the page

### DIFF
--- a/public/stylesheets/index.css
+++ b/public/stylesheets/index.css
@@ -53,8 +53,8 @@ div > h1 {
   flex-direction: column;
   width: 64%;
   height: 100%;
-  justify-content: center;
   align-items: center;
+  min-height: 45rem;
 }
 .wrapper {
   display: flex;


### PR DESCRIPTION
small edit to make the footer not appear in the middle of the screen when content above doesnt fill the body